### PR TITLE
Adding opt-outs

### DIFF
--- a/renpy/config.py
+++ b/renpy/config.py
@@ -984,6 +984,9 @@ load_failed_label = None
 equal_mono = True
 
 
+# Should the default input caret blink ?
+input_caret_blink = True
+
 del os
 del collections
 

--- a/renpy/display/behavior.py
+++ b/renpy/display/behavior.py
@@ -1104,6 +1104,7 @@ class Input(renpy.text.text.Text):  # @UndefinedVariable
                  pixel_width=None,
                  value=None,
                  copypaste=False,
+                 caret_blink=renpy.config.input_caret_blink,
                  **properties):
 
         super(Input, self).__init__("", style=style, replaces=replaces, substitute=False, **properties)
@@ -1135,9 +1136,13 @@ class Input(renpy.text.text.Text):  # @UndefinedVariable
             if i.endswith("color"):
                 caretprops[i] = properties[i]
 
-        self.caret = renpy.store.Fixed(renpy.display.anim.Animation(
-            renpy.display.image.Solid(xsize=1, style=style, **caretprops), 0.5,
-            renpy.display.layout.Null(xsize=1), 0.5), xsize=0, yfill=True)
+        caret = renpy.display.image.Solid(xsize=1, style=style, **caretprops)
+        if caret_blink:
+            self.caret = renpy.store.Fixed(renpy.display.anim.Animation(caret, 0.5,
+                                                                        renpy.display.layout.Null(xsize=1), 0.5),
+                                           xsize=0, yfill=True)
+        else:
+            self.caret = renpy.store.Fixed(caret, xsize=0)
         self.caret_pos = len(self.content)
         self.old_caret_pos = self.caret_pos
 

--- a/sphinx/source/config.rst
+++ b/sphinx/source/config.rst
@@ -538,6 +538,10 @@ Occasionally Used
     can be repeatedly loaded, hurting performance. If not none,
     :var:`config.image_cache_size` is used instead of this variable.
 
+.. var:: config.input_caret_blink = True
+
+    Sets whether or not the default caret in an input will blink or not.
+
 .. var:: config.key_repeat = (.3, .03)
 
     Controls the rate of keyboard repeat. When key repeat is enabled, this

--- a/sphinx/source/screens.rst
+++ b/sphinx/source/screens.rst
@@ -668,6 +668,9 @@ The input statement takes no parameters, and the following properties:
     A Python function that is called with what the user has typed,
     when the string changes.
 
+`caret_blink`
+    If True, the default caret will blink. Overrides :var:`config.input_caret_blink`.
+
 
 It also takes:
 

--- a/sphinx/source/style_properties.rst
+++ b/sphinx/source/style_properties.rst
@@ -445,7 +445,7 @@ Text Style Properties
 
     If not None, this should be a displayable. The input widget will
     use this as the caret at the end of the text. If None, a 1 pixel
-    wide line is used as the caret.
+    wide blinking line is used as the caret.
 
 .. style-property:: color color
 


### PR DESCRIPTION
I was wandering around public ren'py forks and I found this awesome old branch.
I didn't want to start a pull request to `renpy/renpy` since it's yours.
I took the liberty to alter it a bit to add opt-outs, both for a specific input and for a whole game, and to document the whole thing.
Plus, the new config variable can be easily disabled for older versions in `renpy/common/00compat.rpy` if you or Tom wish so - but I don't think it's worth it.
Would you like to merge this and keep the whole thing yours, or shall I (with your blessing) introduce my version as a pull request ?